### PR TITLE
fix(lifecycle): move lifecycle function into separate files to support TS

### DIFF
--- a/src/api/component.js
+++ b/src/api/component.js
@@ -22,6 +22,9 @@ import getSetProps from './props';
 import initProps from '../lifecycle/props-init';
 import syncPropToAttr from '../util/sync-prop-to-attr';
 import root from 'window-or-global';
+import renderer from '../util/lifecycle-renderer';
+import rendered from '../util/lifecycle-rendered';
+import updated from '../util/lifecycle-updated';
 
 const HTMLElement = root.HTMLElement || class {};
 const _prevName = createSymbol('prevName');
@@ -271,28 +274,16 @@ export default class extends HTMLElement {
     }
   }
 
-  // Skate
-  //
-  // Maps to the static updated() callback. That logic should be moved here
-  // when that is finally removed.
   updatedCallback (prev) {
-    return this.constructor.updated(this, prev);
+    return updated(this, prev);
   }
 
-  // Skate
-  //
-  // Maps to the static rendered() callback. That logic should be moved here
-  // when that is finally removed.
   renderedCallback () {
-    return this.constructor.rendered(this);
+    return rendered(this);
   }
 
-  // Skate
-  //
-  // Maps to the static renderer() callback. That logic should be moved here
-  // when that is finally removed.
   rendererCallback () {
-    return this.constructor.renderer(this);
+    return renderer(this);
   }
 
   // Skate
@@ -347,51 +338,23 @@ export default class extends HTMLElement {
   //
   // DEPRECATED
   //
-  // Move this to rendererCallback() before removing.
   static updated (elem, prev) {
-    if (!prev) {
-      return true;
-    }
-
-    // use get all keys so that we check Symbols as well as regular props
-    // using a for loop so we can break early
-    const allKeys = getAllKeys(prev);
-    for (let i = 0; i < allKeys.length; i += 1) {
-      if (prev[allKeys[i]] !== elem[allKeys[i]]) {
-        return true;
-      }
-    }
-
-    return false;
+    return updated(elem, prev);
   }
 
   // Skate
   //
   // DEPRECATED
   //
-  // Move this to rendererCallback() before removing.
-  static rendered () {}
+  static rendered () {
+    rendered();
+  }
 
   // Skate
   //
   // DEPRECATED
   //
-  // Move this to rendererCallback() before removing.
   static renderer (elem) {
-    if (!elem.shadowRoot) {
-      elem.attachShadow({ mode: 'open' });
-    }
-    patchInner(elem.shadowRoot, () => {
-      const possibleFn = elem.renderCallback();
-      if (typeof possibleFn === 'function') {
-        possibleFn();
-      } else if (Array.isArray(possibleFn)) {
-        possibleFn.forEach((fn) => {
-          if (typeof fn === 'function') {
-            fn();
-          }
-        });
-      }
-    });
+    renderer(elem);
   }
 }

--- a/src/util/lifecycle-rendered.js
+++ b/src/util/lifecycle-rendered.js
@@ -1,0 +1,1 @@
+export default function rendered() {}

--- a/src/util/lifecycle-renderer.js
+++ b/src/util/lifecycle-renderer.js
@@ -1,0 +1,19 @@
+import { patchInner } from 'incremental-dom';
+
+export default function renderer (elem) {
+  if (!elem.shadowRoot) {
+    elem.attachShadow({ mode: 'open' });
+  }
+  patchInner(elem.shadowRoot, () => {
+    const possibleFn = elem.renderCallback();
+    if (typeof possibleFn === 'function') {
+      possibleFn();
+    } else if (Array.isArray(possibleFn)) {
+      possibleFn.forEach((fn) => {
+        if (typeof fn === 'function') {
+          fn();
+        }
+      });
+    }
+  });
+}

--- a/src/util/lifecycle-updated.js
+++ b/src/util/lifecycle-updated.js
@@ -1,0 +1,18 @@
+import getAllKeys from './get-all-keys';
+
+export default function updated(elem, prev) {
+  if (!prev) {
+    return true;
+  }
+
+  // use get all keys so that we check Symbols as well as regular props
+  // using a for loop so we can break early
+  const allKeys = getAllKeys(prev);
+  for (let i = 0; i < allKeys.length; i += 1) {
+    if (prev[allKeys[i]] !== elem[allKeys[i]]) {
+      return true;
+    }
+  }
+
+  return false;
+}


### PR DESCRIPTION
To fully support writing components in TS we needed to do some changes.

We tested on this component: 
```javascript
class XCounter extends Component {

  static get is(){ return 'x-counter' }

  renderCallback(){
    return (<div>Hello</div>)
  }

}

window.customElements.define( XCounter.is, XCounter );

```

We had encountered following errors in your PR:
- this.constructor.render is undefined
- this.constructor.rendered is undefined
- this.constructor.updated is undefined

To fix that we just had to separate functions into separate functions, so that they can be used in callbacks as well as in the static functions.

What do you think? Is it possible to merge it into your PR in SkateJS so that the fix is complete?